### PR TITLE
Fix tool-calling data pipeline for JSONL training

### DIFF
--- a/training/src/hmf/data/converter.py
+++ b/training/src/hmf/data/converter.py
@@ -239,6 +239,16 @@ class OpenAIDatasetConverter(DatasetConverter):
         }
 
         messages = example[self.dataset_attr.messages]
+        if isinstance(messages, str):
+            messages = json.loads(messages)
+
+        if self.dataset_attr.tools:
+            _tools_raw = example.get(self.dataset_attr.tools)
+            if _tools_raw is None:
+                example[self.dataset_attr.tools] = []
+            elif isinstance(_tools_raw, str):
+                example[self.dataset_attr.tools] = json.loads(_tools_raw)
+
         if (
             self.dataset_attr.system_tag
             and len(messages) != 0
@@ -257,7 +267,7 @@ class OpenAIDatasetConverter(DatasetConverter):
             content = message[self.dataset_attr.content_tag]
 
             if role in [self.dataset_attr.assistant_tag, self.dataset_attr.function_tag]:
-                if "tool_calls" in message and len(message["tool_calls"]) > 0:
+                if "tool_calls" in message and message["tool_calls"] is not None and len(message["tool_calls"]) > 0:
                     tool_calls_list = [tool["function"] for tool in message["tool_calls"]]
                     content = json.dumps(tool_calls_list, ensure_ascii=False)
                     role = self.dataset_attr.function_tag

--- a/training/src/hmf/data/data_utils.py
+++ b/training/src/hmf/data/data_utils.py
@@ -324,7 +324,6 @@ def load_jsonl(filepath, dataset_attr, cache_dir=None):
         cache_dir=cache_dir,
         features=features,
     )
-    dataset.set_transform(deserialize_transform)
     return dataset
 
 

--- a/training/src/hmf/data/formatter.py
+++ b/training/src/hmf/data/formatter.py
@@ -105,7 +105,12 @@ class FunctionFormatter(StringFormatter):
                 if not isinstance(tool_calls, list):  # parallel function call
                     tool_calls = [tool_calls]
 
-                return [FunctionCall(tc["name"], json.dumps(tc["arguments"], ensure_ascii=False)) for tc in tool_calls]
+                def _normalize_arguments(args):
+                    if isinstance(args, str):
+                        return args
+                    return json.dumps(args, ensure_ascii=False)
+
+                return [FunctionCall(tc["name"], _normalize_arguments(tc["arguments"])) for tc in tool_calls]
             except json.JSONDecodeError:
                 raise RuntimeError(f"Invalid JSON format in function message: {str([content])}.")
 

--- a/training/src/hmf/data/tool_utils.py
+++ b/training/src/hmf/data/tool_utils.py
@@ -157,7 +157,7 @@ class DefaultToolUtils(ToolUtils):
         for tool in tools:
             tool = tool.get("function", "") if tool.get("type") == "function" else tool
             param_text = ""
-            for name, param in tool["parameters"]["properties"].items():
+            for name, param in tool.get("parameters", {}).get("properties", {}).items():
                 required, enum, items = "", "", ""
                 if name in tool["parameters"].get("required", []):
                     required = ", required"


### PR DESCRIPTION
## Summary

Fixes 5 bugs that block or corrupt tool-calling training when using JSONL data with OpenAI chat format (`messages` + `tools` columns). Discovered while training Qwen3.6-35B on multi-turn agentic data with tool calls.

- **Bug 1:** `set_transform` in `load_jsonl` doesn't fire during `.map()` — converter receives raw JSON strings
- **Bug 2:** Materializing parsed messages into Arrow fails on heterogeneous `tool_calls` structure (`ArrowInvalid: cannot mix list and non-list`)
- **Bug 3:** `len(message["tool_calls"])` crashes when Arrow pads `None` for messages without tool calls
- **Bug 4:** `json.dumps(arguments)` double-encodes when `arguments` is already a JSON string (per OpenAI spec)
- **Bug 5:** `tool["parameters"]["properties"]` crashes on tools with no parameters

## Fix approach

- Remove `set_transform` from `load_jsonl` (data stays as strings in Arrow)
- Deserialize inline at the top of `OpenAIDatasetConverter.__call__` — Arrow never sees heterogeneous structure
- Add None guard, handle both string/dict arguments, use `.get()` for properties

## Test plan

- [ ] Train with JSONL tool-calling data in OpenAI format (`formatting: "openai"`, `columns: {messages, tools}`)
- [ ] Verify tools with no parameters don't crash
- [ ] Verify arguments in both dict and string format produce correct tokenization